### PR TITLE
Add language switch and translation support

### DIFF
--- a/functions/deepseek_translate.php
+++ b/functions/deepseek_translate.php
@@ -1,0 +1,37 @@
+<?php
+header('Content-Type: application/json; charset=utf-8');
+$data = json_decode(file_get_contents('php://input'), true);
+$text = $data['text'] ?? '';
+$target = $data['target'] ?? 'en';
+
+$apiKey = 'YOUR_DEEPSEEK_API_KEY';
+$url = 'https://api.deepseek.com/v1/translate';
+
+$payload = json_encode([
+    'text' => $text,
+    'target_lang' => $target
+]);
+
+$ch = curl_init($url);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_POST, true);
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Content-Type: application/json',
+    'Authorization: Bearer ' . $apiKey
+]);
+curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+
+$response = curl_exec($ch);
+$error = curl_error($ch);
+curl_close($ch);
+
+if($error){
+    echo json_encode(['text' => $text]);
+    exit();
+}
+
+$result = json_decode($response, true);
+$translated = $result['translation'] ?? $text;
+
+echo json_encode(['text' => $translated]);
+

--- a/includes/head.php
+++ b/includes/head.php
@@ -40,6 +40,7 @@
 <script src="//code.jquery.com/ui/1.11.4/jquery-ui.js"></script>
 <script src="js/respond.min.js"></script>
 <script src="js/scripts.js"></script>
-<script src="js/jquery.maskedinput.js" type="text/javascript"></script> 
+<script src="js/jquery.maskedinput.js" type="text/javascript"></script>
+<script src="js/translator.js"></script> 
 <script src='https://www.google.com/recaptcha/api.js'></script>
 

--- a/includes/top.php
+++ b/includes/top.php
@@ -10,7 +10,7 @@
           </select> 
            -->
       </div>
-      <div class='top-fixed-language'><!-- <div id='language-changer'>En</div> --></div>
+      <div class='top-fixed-language'><div id='language-changer'>EN</div></div>
       <div class='top-fixed-separator'></div>
       <div class='top-fixed-services'><a href='services.html' rel='nofollow'><div id='services-tarif' title='Услуги курьерской доставки и тарифа на услуги курьерской доставки'>Услуги и тарифы</div></a></div>
       <div class='top-fixed-services'><a href='https://p.shipperty.ru' target="_blank" rel='nofollow'><div id='private-cabinet' title='Вход для клиентов службы доставки Shipperty'>Личный кабинет</div></a></div>

--- a/index.html
+++ b/index.html
@@ -42,7 +42,8 @@
 <script async src="js/respond.min.js"></script>
 
 
-<script async src="js/jquery.maskedinput.js" type="text/javascript"></script> 
+<script async src="js/jquery.maskedinput.js" type="text/javascript"></script>
+<script defer src="js/translator.js"></script> 
 <script src="https://www.google.com/recaptcha/api.js"></script>
 
      
@@ -87,7 +88,7 @@ data-callback="callBackDo">
              <option value='spb'>г.Санкт-Петербург</option>
           </select>  -->
       </div>
-     <div class='top-fixed-language'> <!-- <div id='language-changer'>En</div> --></div>
+     <div class='top-fixed-language'><div id='language-changer'>EN</div></div>
       <div class='top-fixed-separator'></div>
       <div class='top-fixed-services'><a href='services.html' rel='nofollow'><div id='services-tarif' title='Услуги курьерской доставки и тарифа на услуги курьерской доставки'>Услуги и тарифы</div></a></div>
       <div class='top-fixed-services'><a href='https://p.shipperty.ru' target="_blank" rel='nofollow'><div id='private-cabinet'  title='Вход для клиентов службы доставки Shipperty'>Личный кабинет</div></a></div>
@@ -144,7 +145,7 @@ data-callback="callBackDo">
              <option value='spb'>C.Петербург</option>
          	 </select>  -->
           </div>
-          <div class='top-fixed-language-tablet'><!-- <div id='language-changer'>En</div> --></div>
+          <div class='top-fixed-language-tablet'><div id='language-changer'>EN</div></div>
           <div class='top-fixed-callback-tablet'><div id='call-back-button' onClick="callBackClick();">ЗАКАЗАТЬ ЗВОНОК</div></div>
           <div class='top-fixed-phone-mobile phone1'>8 (495) 258-62-01</div>
       </div>

--- a/js/translator.js
+++ b/js/translator.js
@@ -1,0 +1,60 @@
+var currentLang = 'ru';
+
+function translateText(text, lang){
+    return fetch('functions/deepseek_translate.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: text, target: lang })
+    })
+    .then(function(r){ return r.json(); })
+    .then(function(data){ return data.text || text; })
+    .catch(function(){ return text; });
+}
+
+function translateDOM(lang){
+    document.querySelectorAll('body *').forEach(function(el){
+        if(el.children.length === 0){
+            var txt = el.textContent.trim();
+            if(!txt){ return; }
+            if(!el.dataset.originalText){
+                el.dataset.originalText = el.textContent;
+            }
+            if(lang === 'ru'){
+                el.textContent = el.dataset.originalText;
+            }else{
+                translateText(el.dataset.originalText, lang).then(function(t){
+                    el.textContent = t;
+                });
+            }
+        }
+    });
+    updateLanguageIcon();
+}
+
+function setLanguage(lang){
+    currentLang = lang;
+    localStorage.setItem('language', lang);
+    translateDOM(lang);
+}
+
+function toggleLanguage(){
+    if(currentLang === 'ru'){ setLanguage('en'); }
+    else{ setLanguage('ru'); }
+}
+
+function updateLanguageIcon(){
+    document.querySelectorAll('#language-changer').forEach(function(el){
+        el.textContent = currentLang === 'ru' ? 'EN' : 'RU';
+    });
+}
+
+document.addEventListener('DOMContentLoaded', function(){
+    var lang = localStorage.getItem('language') || 'ru';
+    currentLang = lang;
+    if(lang !== 'ru'){ translateDOM(lang); }
+    updateLanguageIcon();
+    document.querySelectorAll('#language-changer').forEach(function(el){
+        el.addEventListener('click', toggleLanguage);
+    });
+});
+


### PR DESCRIPTION
## Summary
- implement DeepSeek-based translation backend
- add JavaScript translator that swaps page language
- show language switcher in header on main and inner pages
- load new translator script on all pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f2a019d98832193a3202fca2ff15a